### PR TITLE
Basic SSL support and docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,3 @@
-# SSL support
-
-Basic HTTPS support is provided for instance when homeassistant with https enabled (e.g. to have mobile app access), https is required.
-I replaved the waitress server, which is more suited to handle serveral requests and can scale with the flask embedded server.
-This works well for the use case of home assistant, where no scalability is needed and only a few clients will do requests.
-But *this should not be used* in a context where many customers and requests are expected.
-
-To enable SSL, certificate and key must be provided either in the settings, throuhg env var, or arguments.
-If one of those is not specified, the server will revert to http.
-
-I've published a docker image as well that can be used. Example of use with docker compose:
-```
-    # Dublin bus real time api
-    tfi:
-        container_name: tfi
-        hostname: tfi
-        image: vche/tfi-gtfs:latest
-        <<: [*common-service, *loki-logging]
-        environment:
-            <<: *common-env
-            API_KEY: f93f81b811324c93bd3567f1d72d0f47
-            REDIS_URL: 192.168.0.195
-            SSL_CERT: "/certs/domodwarf/domodwarf-cert.pem"
-            SSL_KEY: "/certs/domodwarf/domodwarf-key.pem"
-        volumes:
-            #     - $DOCKERDIR/config/settings.py:/app/settings.py:ro
-            - $DOCKERDIR/syncthing/config/Sync/certs:/certs
-        ports:
-            - 7341:7341
-```
-
 # Transport for Ireland GTFS REST API
 This project implements a simple REST server and command line utility for retrieving real-time information about public transport in Ireland (at least, for services operated by Dublin Bus, Bus Éireann, and Go-Ahead Ireland).
 
@@ -178,7 +147,7 @@ This works well for the use case of home assistant, where no scalability is need
 But *this should not be used* in a context where many customers and requests are expected.
 
 To enable SSL, certificate and key must be provided either in the settings, throuhg env var, or arguments.
-If one of those is not specified, the server will revert to http.
+If none of those is not specified, the server will revert to http.
 
 I've published a [docker image](https://hub.docker.com/r/vche/tfi-gtfs) as well that can be used. Example of use with docker compose:
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
-Fork from https://github.com/seanblanchfield/tfi-gtfs to add https support.
-For instance when used from homeassistant with https enabled (e.g. to have mobile app access), https is required.
+# SSL support
+
+Basic HTTPS support is provided for instance when homeassistant with https enabled (e.g. to have mobile app access), https is required.
 I replaved the waitress server, which is more suited to handle serveral requests and can scale with the flask embedded server.
 This works well for the use case of home assistant, where no scalability is needed and only a few clients will do requests.
 But *this should not be used* in a context where many customers and requests are expected.
 
 To enable SSL, certificate and key must be provided either in the settings, throuhg env var, or arguments.
 If one of those is not specified, the server will revert to http.
+
+I've published a docker image as well that can be used. Example of use with docker compose:
+```
+    # Dublin bus real time api
+    tfi:
+        container_name: tfi
+        hostname: tfi
+        image: vche/tfi-gtfs:latest
+        <<: [*common-service, *loki-logging]
+        environment:
+            <<: *common-env
+            API_KEY: f93f81b811324c93bd3567f1d72d0f47
+            REDIS_URL: 192.168.0.195
+            SSL_CERT: "/certs/domodwarf/domodwarf-cert.pem"
+            SSL_KEY: "/certs/domodwarf/domodwarf-key.pem"
+        volumes:
+            #     - $DOCKERDIR/config/settings.py:/app/settings.py:ro
+            - $DOCKERDIR/syncthing/config/Sync/certs:/certs
+        ports:
+            - 7341:7341
+```
 
 # Transport for Ireland GTFS REST API
 This project implements a simple REST server and command line utility for retrieving real-time information about public transport in Ireland (at least, for services operated by Dublin Bus, Bus Éireann, and Go-Ahead Ireland).
@@ -147,6 +169,32 @@ docker run -p 7341:7341 -v ./settings.py:/app/settings.py:ro tfi-gtfs
 ```
 
 In the above examples, `7341` is the default port number used by the API server. You could map port `8000` on the host to `7341` in the container by instead specifying `-p 8000:7341`.
+
+### SSL support
+
+Basic HTTPS support is provided for instance when homeassistant with https enabled (e.g. to have mobile app access), https is required.
+I replaved the waitress server, which is more suited to handle serveral requests and can scale with the flask embedded server.
+This works well for the use case of home assistant, where no scalability is needed and only a few clients will do requests.
+But *this should not be used* in a context where many customers and requests are expected.
+
+To enable SSL, certificate and key must be provided either in the settings, throuhg env var, or arguments.
+If one of those is not specified, the server will revert to http.
+
+I've published a [docker image](https://hub.docker.com/r/vche/tfi-gtfs) as well that can be used. Example of use with docker compose:
+```
+    # Dublin bus real time api
+    tfi:
+        image: vche/tfi-gtfs:latest
+        environment:
+            API_KEY: f93g81b821324593bd3563f1d72f0f47
+            REDIS_URL: 192.168.0.165
+            SSL_CERT: "/certs/server-cert.pem"
+            SSL_KEY: "/certs/server-key.pem"
+        volumes:
+            - $DOCKERDIR/certs:/certs
+        ports:
+            - 7341:7341
+```
 
 ## Running in Home Assistant
 This project is also available as a *Home Assistant* addon. Visit my [Home Assistant Addons repository](https://github.com/seanblanchfield/seans-homeassistant-addons) for more information on how to add that repository to your Home Assistant installation and install the addon.

--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,8 @@ HOST = os.environ.get('HOST', 'localhost')
 PORT = os.environ.get('PORT', 7341)
 WORKERS = os.environ.get('WORKERS', 1)
 DATA_DIR = Path(os.environ.get('DATA_DIR', 'data'))
+SSL_CERT = os.environ.get('SSL_CERT', None)
+SSL_KEY = os.environ.get('SSL_KEY', None)
 
 # set default logging level to INFO
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
@@ -26,7 +28,7 @@ if FILTER_STOPS:
     FILTER_STOPS = [stop.strip() for stop in FILTER_STOPS.split(',')]
 
 # Optionally create a `local_settings.py` file to override these settings
-# during development. This file will be ignored by git. 
+# during development. This file will be ignored by git.
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
This CR adds a `basic` ssl support, useful for installations using the mobile app which requires https, and browsers will block the hass plugin requests to the tf-gts backend if they aren't protected.

By `basic`, i mean that the waitress server is replaced here by the flask development server, meaning it is not scalable or able to handle high requests loads.

While this only adds a new feature and doesn't impact the http mode, feel free to reject this PR if you wish to keep your repo "efficient/production ready". I sent this in case you're interested in merging the feature.